### PR TITLE
add the additional_files attr to the module extension

### DIFF
--- a/npm/extensions.bzl
+++ b/npm/extensions.bzl
@@ -20,6 +20,7 @@ def _extension_impl(module_ctx):
             # the pnpm-lock.yaml file when update_pnpm_lock is True.
             npm_translate_lock(
                 name = attr.name,
+                additional_file_contents = attr.additional_file_contents,
                 bins = attr.bins,
                 custom_postinstalls = attr.custom_postinstalls,
                 data = attr.data,


### PR DESCRIPTION
Adds the `additional_file_contents` attribute to the `npm_translate_lock` module extension; which enables inserting additonal content to the external repository `BUILD.bazel` to reference in downstream consumers.

For example, creating an external repository for `my_js_tools_npm` from the `tools_repo` that should be usable from custom rules/macros:

```starlark
# //tools_repo/MODULE.bazel
npm.npm_translate_lock(
    name = "my_js_tools_npm",
    link_workspace = "my_js_tools_npm",
    npmrc = "//:.npmrc",
    root_package = "",
    pnpm_lock = "//:pnpm-lock.yaml",
    additional_file_contents = {
        "BUILD.bazel": [
            """load("//:defs.bzl", "npm_link_all_packages")""",
            """npm_link_all_packages(name="node_modules")""",
        ]
    },
)

use_repo(npm, "my_js_tools_npm")
```

... defining the tool binary in the `tools_repo`

```starlark
# //tools_repo/tools/BUILD.bazel
load("@my_js_tools_npm//:@bufbuild/protoc-gen-es/package_json.bzl", protoc_gen_es_binary = "bin")

protoc_gen_es_binary.protoc_gen_es_binary(
    name = "protoc-gen-es",
    data = ["@my_js_tools_npm//:node_modules"],
    include_npm_linked_packages = True,
    visibility = ["//visibility:public"],
)
```

... and finally using the binary in a downstream repo
```starlark
# //new_repo/MODULE.bazel
bazel_dep(name="tools_repo", version="0.0.0")
```

```starlark
# //new_repo/BUILD.bazel
...
some_protoc_rule(
    name = "bad_example",
    srcs   = glob(["*.proto"]),
    plugins = ["@tools_repo/tools:protoc-gen-es"],
)
```